### PR TITLE
docs: update poetry command at chapter1 - 1.1.get-camel.md

### DIFF
--- a/docs/chapter1/1.1.get-camel.md
+++ b/docs/chapter1/1.1.get-camel.md
@@ -82,10 +82,13 @@ poetry env use python3.10  # （可选）
 
 ```bash
 # 激活 camel 虚拟环境，出现类似(camel-ai-py3.10) C:\camel>中左侧的（虚拟环境）代表激活成功
-poetry shell
+poetry env activate
 ```
 
-
+如果您安装的是 Poetry 2.0.0 之前的版本，则使用以下命令激活：
+```bash
+poetry shell
+```
 
 ![](../images/image-1-1741229381092-12.png)
 

--- a/docs/chapter1/1.1.get-camel.md
+++ b/docs/chapter1/1.1.get-camel.md
@@ -82,15 +82,15 @@ poetry env use python3.10  # （可选）
 
 ```bash
 # 激活 camel 虚拟环境，出现类似(camel-ai-py3.10) C:\camel>中左侧的（虚拟环境）代表激活成功
-poetry env activate
-```
-
-如果您安装的是 Poetry 2.0.0 之前的版本，则使用以下命令激活：
-```bash
 poetry shell
 ```
 
 ![](../images/image-1-1741229381092-12.png)
+
+如果您安装的是 Poetry 2.0.0 以上版本，则使用以下命令激活：
+```bash
+poetry env activate
+```
 
 * 安装所有依赖：
 


### PR DESCRIPTION
```shell
❯ poetry shell

Looks like you're trying to use a Poetry command that is not available.

Since Poetry (2.0.0), the shell command is not installed by default. You can use,

  - the new env activate command (recommended); or
  - the shell plugin to install the shell command

Documentation: https://python-poetry.org/docs/managing-environments/#activating-the-environment

Note that the env activate command is not a direct replacement for shell command.
```

https://github.com/python-poetry/poetry/releases/tag/2.0.0